### PR TITLE
No need for approve

### DIFF
--- a/contracts/TeachersPet.sol
+++ b/contracts/TeachersPet.sol
@@ -90,8 +90,7 @@ contract TeachersPet is StandardToken {
 
     require(duplicate == false);
     students[_student].milestones.push(_title);
-    students[_student].tokensReceived += milestones[_title].reward;
-    approve(_student, milestones[_title].reward);
+    students[_student].tokensReceived += milestones[_title].reward;    
     transfer(_student, milestones[_title].reward);
     emit MilestoneAwarded(_student, milestones[_title].reward, _title, milestones[_title].tags);
   }


### PR DESCRIPTION
Since there are both "approve"  and "transfer", the student could get double rewards. 
As long as he received the amount transferred to him/her, he/she may get the same amount of tokens again by "transferFrom(_admin, _student, milestones[_title].reward).